### PR TITLE
Corrected issue regarding browser validation message for float number inputs

### DIFF
--- a/packages/preferences/src/browser/views/components/preference-number-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-number-input.ts
@@ -53,6 +53,7 @@ export class PreferenceNumberInputRenderer extends PreferenceLeafNodeRenderer<nu
         const interactable = document.createElement('input');
         this.interactable = interactable;
         interactable.type = 'number';
+        interactable.step = this.preferenceNode.preference.data.type === 'integer' ? '1' : 'any';
         interactable.classList.add('theia-input');
         interactable.defaultValue = this.getValue()?.toString() ?? '';
         interactable.oninput = this.handleUserInteraction.bind(this);


### PR DESCRIPTION
#### What it does
For the preference number input if a float should be accepted in that field there will be no more a failure message showing.
Closes #11851


#### How to test
1.	Go into file: preference: Open Setting
2.	Find a field that should accept a float value
3.	Enter a float value
4.	There should be no message appearing
5.	Try a field that should only take an integer 
6.	Enter a float value
7.	The failure message regarding the value being incorrect should appear


https://user-images.githubusercontent.com/113064863/207617244-46de9cb1-a46b-46e3-9bfb-5173c313b251.mp4




https://user-images.githubusercontent.com/113064863/207618036-34baea9f-acde-4479-98f9-4c7931a5a537.mp4






#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
